### PR TITLE
Ignore case sensitivity for custom allowed headers

### DIFF
--- a/context-propagation/baseproviders/allowedheaders/allowed_headers_context_object.go
+++ b/context-propagation/baseproviders/allowedheaders/allowed_headers_context_object.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/netcracker/qubership-core-lib-go/v3/context-propagation/ctxmanager"
 	"strings"
+
+	"github.com/netcracker/qubership-core-lib-go/v3/context-propagation/ctxmanager"
 )
 
 type allowedHeaderContextObject struct {
@@ -16,8 +17,34 @@ func NewAllowedHeaderContextObject(headers map[string]string) allowedHeaderConte
 	return allowedHeaderContextObject{header: headers}
 }
 
+// GetHeaders returns raw map of headers with values. Keys in map are case-sensitive.
+// Use GetHeader to get header value in case-insentitive way
+// Use GetHeaderNames to get list of available custom headers in context
 func (allowedHeaderContextObject allowedHeaderContextObject) GetHeaders() map[string]string {
 	return allowedHeaderContextObject.header
+}
+
+// GetHeader method returns value by header name and true if exists
+// It works in case-insensitive way
+func (allowedHeaderContextObject allowedHeaderContextObject) GetHeader(header string) (string, bool) {
+	loweredHeader := strings.ToLower(header)
+	for headerName, value := range allowedHeaderContextObject.header {
+		if strings.ToLower(headerName) == loweredHeader {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+// GetHeaderNames method returns slice of available headers in context
+func (allowedHeaderContextObject allowedHeaderContextObject) GetHeaderNames() []string {
+	headerNames := make([]string, len(allowedHeaderContextObject.header))
+	i := 0
+	for headerName := range allowedHeaderContextObject.header {
+		headerNames[i] = headerName
+		i++
+	}
+	return headerNames
 }
 
 func (allowedHeaderContextObject allowedHeaderContextObject) GetLogValue() string {

--- a/context-propagation/baseproviders/allowedheaders/allowed_headers_provider.go
+++ b/context-propagation/baseproviders/allowedheaders/allowed_headers_provider.go
@@ -21,11 +21,33 @@ func init() {
 }
 
 type allowedHeaderProvider struct {
-	allowedHeaders []string
+	allowedHeaders allowedHeaderSet
+}
+
+// allowedHeaderSet provides methods to work with header names in case-insensitive way
+// It stores allowed headers in lowered header format for future comparison
+type allowedHeaderSet map[string]struct{}
+
+// add method is using to build initial set of headers formatted to lowered format
+func (s allowedHeaderSet) add(allowedHeader string) {
+	s[strings.ToLower(allowedHeader)] = struct{}{}
+}
+
+// isAllowedHeader using to check if header name is allowed by comparison lowered format
+func (s allowedHeaderSet) isAllowedHeader(header string) bool {
+	_, ok := s[strings.ToLower(header)]
+	return ok
 }
 
 func NewAllowedHeaderProvider() allowedHeaderProvider {
-	return allowedHeaderProvider{allowedHeaders: strings.Split(strings.ReplaceAll(configloader.GetOrDefaultString(HEADERS_PROPERTY, ""), " ", ""), ",")}
+	allowedHeadersRaw := strings.Split(strings.ReplaceAll(configloader.GetOrDefaultString(HEADERS_PROPERTY, ""), " ", ""), ",")
+	allowedHeaders := allowedHeaderSet{}
+	for _, header := range allowedHeadersRaw {
+		allowedHeaders.add(header)
+	}
+	return allowedHeaderProvider{
+		allowedHeaders: allowedHeaders,
+	}
 }
 
 func (allowedHeaderProvider allowedHeaderProvider) InitLevel() int {
@@ -38,12 +60,14 @@ func (allowedHeaderProvider allowedHeaderProvider) ContextName() string {
 
 func (allowedHeaderProvider allowedHeaderProvider) Provide(ctx context.Context, incomingData map[string]interface{}) context.Context {
 	var allowedRequestHeaders = make(map[string]string)
-	for _, headerName := range allowedHeaderProvider.allowedHeaders {
-		if incomingData[headerName] != nil {
-			allowedRequestHeaders[headerName] = incomingData[headerName].(string)
+
+	for headerName, value := range incomingData {
+		if allowedHeaderProvider.allowedHeaders.isAllowedHeader(headerName) {
+			allowedRequestHeaders[headerName] = value.(string)
 			logger.Debug("context object=" + headerName + " provided to context.Context")
 		}
 	}
+
 	return context.WithValue(ctx, ALLOWED_HEADER_CONTEX_NAME, NewAllowedHeaderContextObject(allowedRequestHeaders))
 }
 
@@ -53,9 +77,9 @@ func (allowedHeaderProvider allowedHeaderProvider) Set(ctx context.Context, allo
 		return ctx, errors.New("incorrect type to set allowedHeaders")
 	}
 	var allowedRequestHeaders = make(map[string]string)
-	for _, headerName := range allowedHeaderProvider.allowedHeaders {
-		if allowedHeaders.header[headerName] != "" {
-			allowedRequestHeaders[headerName] = allowedHeaders.header[headerName]
+	for headerName, value := range allowedHeaders.header {
+		if allowedHeaderProvider.allowedHeaders.isAllowedHeader(headerName) {
+			allowedRequestHeaders[headerName] = value
 			logger.Debug("context object=" + headerName + " set to context.Context")
 		}
 	}


### PR DESCRIPTION
### Changelist:
- Added new struct `allowedHeaderSet` which compares headers from incoming context with headers from `ALLOWED_HEADERS` env variables in lowered format
- Added public methods to `GetHeader` value ignoring case sensitivity (comparison in lowered format)
- Headers stays unchanged

### Testing:
- Covered by UT