### PR TITLE
test: modify security/rest client tests to actually test using a real jwt token

### DIFF
--- a/security/rest/client_test.go
+++ b/security/rest/client_test.go
@@ -50,8 +50,9 @@ func TestM2MRestClient_DoRequest_FirstCallSuccess(t *testing.T) {
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	require.NoError(t, err)
 
-	now := time.Now().Unix()
-	exp := time.Now().Add(time.Hour).Unix()
+	issued := time.Now()
+    now := issued.Unix()
+    exp := issued.Add(time.Hour).Unix()
 	claims := jwt.MapClaims{
 		"aud": []string{"test"},
 		"exp": exp,

--- a/security/rest/client_test.go
+++ b/security/rest/client_test.go
@@ -3,6 +3,8 @@ package rest
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
 	"errors"
 	"io"
 	"net/http"
@@ -10,9 +12,14 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
+	"github.com/MicahParks/jwkset"
+	"github.com/MicahParks/keyfunc/v3"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/knadh/koanf/providers/confmap"
 	"github.com/netcracker/qubership-core-lib-go/v3/configloader"
+	"github.com/netcracker/qubership-core-lib-go/v3/security/tokenverifier"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -40,9 +47,52 @@ func TestKubernetesAuthHeaderFunc(t *testing.T) {
 }
 
 func TestM2MRestClient_DoRequest_FirstCallSuccess(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	now := time.Now().Unix()
+	exp := time.Now().Add(time.Hour).Unix()
+	claims := jwt.MapClaims{
+		"aud": []string{"test"},
+		"exp": exp,
+		"iat": now,
+		"iss": "https://kubernetes.default.svc.cluster.local",
+		"kubernetes.io": map[string]interface{}{
+			"namespace": "test",
+			"serviceaccount": map[string]interface{}{
+				"name": "test",
+			},
+		},
+		"nbf": now,
+		"sub": "system:serviceaccount:test:test",
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	tokenString, err := token.SignedString(privateKey)
+	require.NoError(t, err)
+
+	jwk, err := jwkset.NewJWKFromKey(privateKey.Public(), jwkset.JWKOptions{})
+	require.NoError(t, err)
+	storage := jwkset.NewMemoryStorage()
+	require.NoError(t, storage.KeyWrite(t.Context(), jwk))
+	keyFunc, err := keyfunc.New(keyfunc.Options{
+		Storage: storage,
+	})
+	require.NoError(t, err)
+
+	parser := jwt.NewParser(jwt.WithAudience("test"), jwt.WithExpirationRequired(), jwt.WithIssuer("https://kubernetes.default.svc.cluster.local"))
+	verifier, err := tokenverifier.NewVerifier(parser, keyFunc)
+	require.NoError(t, err)
+
 	// Mock HTTP server that returns 200 OK
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "Bearer new-token", r.Header.Get("Authorization"))
+		token, _ := strings.CutPrefix(r.Header.Get("Authorization"), "Bearer ")
+		_, err := verifier.Verify(t.Context(), token)
+		assert.NoError(t, err)
+		if err != nil {
+			w.WriteHeader(http.StatusUnauthorized)
+			w.Write([]byte(`{"status":"failure"}`))
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`{"status":"success"}`))
 	}))
@@ -51,10 +101,10 @@ func TestM2MRestClient_DoRequest_FirstCallSuccess(t *testing.T) {
 	client := &M2MRestClient{
 		client:                  server.Client(),
 		urlCache:                newUrlCache(),
-		k8sAuthHeader:           mockAuthHeaderFunc("Bearer new-token", nil),
+		k8sAuthHeader:           mockAuthHeaderFunc("Bearer "+tokenString, nil),
 		fallbackAuthHeader:      mockAuthHeaderFunc("Bearer fallback-token", nil),
 		internalGatewayHostname: "internal-gateway-service",
-		k8sM2mEnabled:              true,
+		k8sM2mEnabled:           true,
 	}
 
 	ctx := context.Background()
@@ -93,7 +143,7 @@ func TestM2MRestClient_DoRequest_FirstCallUnauthorized_FallbackSuccess(t *testin
 		k8sAuthHeader:           mockAuthHeaderFunc("Bearer new-token", nil),
 		fallbackAuthHeader:      mockAuthHeaderFunc("Bearer fallback-token", nil),
 		internalGatewayHostname: "internal-gateway-service",
-		k8sM2mEnabled:              true,
+		k8sM2mEnabled:           true,
 	}
 
 	ctx := context.Background()
@@ -126,7 +176,7 @@ func TestM2MRestClient_DoRequest_TokenAcquisitionError_Fallback(t *testing.T) {
 		k8sAuthHeader:           mockAuthHeaderFunc("", errors.New("token acquisition failed")),
 		fallbackAuthHeader:      mockAuthHeaderFunc("Bearer fallback-token", nil),
 		internalGatewayHostname: "internal-gateway-service",
-		k8sM2mEnabled:              true,
+		k8sM2mEnabled:           true,
 	}
 
 	ctx := context.Background()
@@ -160,7 +210,7 @@ func TestM2MRestClient_DoRequest_CachedUrl_UsesFallback(t *testing.T) {
 		k8sAuthHeader:           mockAuthHeaderFunc("Bearer new-token", nil),
 		fallbackAuthHeader:      mockAuthHeaderFunc("Bearer fallback-token", nil),
 		internalGatewayHostname: "internal-gateway-service",
-		k8sM2mEnabled:              true,
+		k8sM2mEnabled:           true,
 	}
 
 	ctx := context.Background()
@@ -198,7 +248,7 @@ func TestM2MRestClient_DoRequest_WithBody(t *testing.T) {
 		client:                  server.Client(),
 		urlCache:                newUrlCache(),
 		k8sAuthHeader:           mockAuthHeaderFunc("Bearer token", nil),
-		k8sM2mEnabled:              true,
+		k8sM2mEnabled:           true,
 		fallbackAuthHeader:      mockAuthHeaderFunc("Bearer fallback", nil),
 		internalGatewayHostname: "internal-gateway-service",
 	}
@@ -230,7 +280,7 @@ func TestM2MRestClient_DoRequest_WithHeaders(t *testing.T) {
 		k8sAuthHeader:           mockAuthHeaderFunc("Bearer token", nil),
 		fallbackAuthHeader:      mockAuthHeaderFunc("Bearer fallback", nil),
 		internalGatewayHostname: "internal-gateway-service",
-		k8sM2mEnabled:              true,
+		k8sM2mEnabled:           true,
 	}
 
 	ctx := context.Background()
@@ -258,7 +308,7 @@ func TestM2MRestClient_DoRequest_InvalidUrl(t *testing.T) {
 		k8sAuthHeader:           mockAuthHeaderFunc("Bearer token", nil),
 		fallbackAuthHeader:      mockAuthHeaderFunc("Bearer fallback", nil),
 		internalGatewayHostname: "internal-gateway-service",
-		k8sM2mEnabled:              true,
+		k8sM2mEnabled:           true,
 	}
 
 	ctx := context.Background()
@@ -280,7 +330,7 @@ func TestM2MRestClient_DoRequest_BothAuthMethodsFail(t *testing.T) {
 		k8sAuthHeader:           mockAuthHeaderFunc("", errors.New("new auth failed")),
 		fallbackAuthHeader:      mockAuthHeaderFunc("", errors.New("fallback auth failed")),
 		internalGatewayHostname: "internal-gateway-service",
-		k8sM2mEnabled:              true,
+		k8sM2mEnabled:           true,
 	}
 
 	ctx := context.Background()
@@ -304,7 +354,7 @@ func TestM2MRestClient_DoRequest_ServerError(t *testing.T) {
 		k8sAuthHeader:           mockAuthHeaderFunc("Bearer token", nil),
 		fallbackAuthHeader:      mockAuthHeaderFunc("Bearer fallback", nil),
 		internalGatewayHostname: "internal-gateway-service",
-		k8sM2mEnabled:              true,
+		k8sM2mEnabled:           true,
 	}
 
 	ctx := context.Background()
@@ -335,7 +385,7 @@ func TestM2MRestClient_DoRequest_ConcurrentRequests(t *testing.T) {
 		k8sAuthHeader:           mockAuthHeaderFunc("Bearer token", nil),
 		fallbackAuthHeader:      mockAuthHeaderFunc("Bearer fallback", nil),
 		internalGatewayHostname: "internal-gateway-service",
-		k8sM2mEnabled:              true,
+		k8sM2mEnabled:           true,
 	}
 
 	ctx := context.Background()
@@ -376,7 +426,7 @@ func TestM2MRestClient_DoRequest_DifferentHttpMethods(t *testing.T) {
 				k8sAuthHeader:           mockAuthHeaderFunc("Bearer token", nil),
 				fallbackAuthHeader:      mockAuthHeaderFunc("Bearer fallback", nil),
 				internalGatewayHostname: "internal-gateway-service",
-				k8sM2mEnabled:              true,
+				k8sM2mEnabled:           true,
 			}
 
 			ctx := context.Background()
@@ -409,7 +459,7 @@ func TestM2MRestClient_DoRequest_FallbackCachesUrl(t *testing.T) {
 		k8sAuthHeader:           mockAuthHeaderFunc("Bearer new-token", nil),
 		fallbackAuthHeader:      mockAuthHeaderFunc("Bearer fallback-token", nil),
 		internalGatewayHostname: "internal-gateway-service",
-		k8sM2mEnabled:              true,
+		k8sM2mEnabled:           true,
 	}
 
 	ctx := context.Background()
@@ -438,7 +488,7 @@ func TestM2MRestClient_DoRequest_BodyReaderError(t *testing.T) {
 		k8sAuthHeader:           mockAuthHeaderFunc("Bearer token", nil),
 		fallbackAuthHeader:      mockAuthHeaderFunc("Bearer fallback", nil),
 		internalGatewayHostname: "internal-gateway-service",
-		k8sM2mEnabled:              true,
+		k8sM2mEnabled:           true,
 	}
 
 	// Create an error reader
@@ -493,7 +543,7 @@ func TestM2MRestClient_DoRequest_InternalGatewayUrlCaching(t *testing.T) {
 		k8sAuthHeader:           mockAuthHeaderFunc("Bearer new-token", nil),
 		fallbackAuthHeader:      mockAuthHeaderFunc("Bearer fallback-token", nil),
 		internalGatewayHostname: "internal-gateway-service",
-		k8sM2mEnabled:              true,
+		k8sM2mEnabled:           true,
 	}
 
 	ctx := context.Background()
@@ -531,7 +581,7 @@ func TestM2MRestClient_DoRequestFallback(t *testing.T) {
 		k8sAuthHeader:           mockAuthHeaderFunc("Bearer new", nil),
 		fallbackAuthHeader:      mockAuthHeaderFunc("Bearer fallback", nil),
 		internalGatewayHostname: "internal-gateway-service",
-		k8sM2mEnabled:              true,
+		k8sM2mEnabled:           true,
 	}
 
 	ctx := context.Background()
@@ -573,7 +623,7 @@ func TestM2MRestClient_DoRequest_MultipleBodyReads(t *testing.T) {
 		k8sAuthHeader:           mockAuthHeaderFunc("Bearer new", nil),
 		fallbackAuthHeader:      mockAuthHeaderFunc("Bearer fallback", nil),
 		internalGatewayHostname: "internal-gateway-service",
-		k8sM2mEnabled:              true,
+		k8sM2mEnabled:           true,
 	}
 
 	ctx := context.Background()
@@ -603,7 +653,7 @@ func TestM2MRestClient_DoRequest_FallbackRebasesUrl(t *testing.T) {
 		fallbackAuthHeader:      mockAuthHeaderFunc("Bearer fallback-token", nil),
 		fallBackBaseUrl:         agentServer.URL,
 		internalGatewayHostname: "internal-gateway-service",
-		k8sM2mEnabled:              true,
+		k8sM2mEnabled:           true,
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Modify security/rest client tests to actually test using a real jwt token. Make a new signed jwt token and actually verify that in httptest handler